### PR TITLE
Fix exception flattening

### DIFF
--- a/src/Slate.Utils/ExceptionUtils.cs
+++ b/src/Slate.Utils/ExceptionUtils.cs
@@ -69,31 +69,35 @@ namespace Slate.Utils
         /// </summary>
         public static Exception Unwrap(Exception ex)
         {
-            return FlattenExceptions(ex).FirstOrDefault();
+            return FlattenExceptions(ex).LastOrDefault();
         }
 
         /// <summary>
-        /// Flatten AggregateExceptions
+        /// Flatten exception hierarchies including AggregateException and <see cref="Exception.InnerException"/> chains.
         /// </summary>
         public static IEnumerable<Exception> FlattenExceptions(Exception ex)
         {
-            if (ex != null)
+            if (ex == null)
             {
-                if (ex is AggregateException ag)
-                {
-                    return ag.InnerExceptions.SelectMany(e => FlattenExceptions(e));
-                }
-                else if (ex is TargetInvocationException te)
-                {
-                    return FlattenExceptions(te.InnerException);
-                }
-                else
-                {
-                    return new[] { ex };
-                }
+                return Enumerable.Empty<Exception>();
             }
 
-            return Enumerable.Empty<Exception>();
+            if (ex is AggregateException ag)
+            {
+                return ag.InnerExceptions.SelectMany(e => FlattenExceptions(e));
+            }
+
+            if (ex is TargetInvocationException te)
+            {
+                return FlattenExceptions(te.InnerException);
+            }
+
+            if (ex.InnerException != null)
+            {
+                return new[] { ex }.Concat(FlattenExceptions(ex.InnerException));
+            }
+
+            return new[] { ex };
         }
 
         /// <summary>

--- a/test/Slate.Utils.Tests/ExceptionUtilsTests.cs
+++ b/test/Slate.Utils.Tests/ExceptionUtilsTests.cs
@@ -1,0 +1,31 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Slate.Utils.Tests
+{
+    public class ExceptionUtilsTests
+    {
+        [Fact]
+        public void FlattenExceptions_IncludesInnerExceptions()
+        {
+            var inner = new InvalidOperationException("inner");
+            var outer = new Exception("outer", inner);
+
+            var result = ExceptionUtils.FlattenExceptions(outer);
+
+            result.Should().ContainInOrder(outer, inner);
+        }
+
+        [Fact]
+        public void Unwrap_ReturnsInnermostException()
+        {
+            var inner = new InvalidOperationException("inner");
+            var outer = new Exception("outer", inner);
+
+            var unwrapped = ExceptionUtils.Unwrap(outer);
+
+            unwrapped.Should().Be(inner);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix `ExceptionUtils.FlattenExceptions` so that it walks normal `InnerException` chains
- update `ExceptionUtils.Unwrap` to return the innermost exception
- add unit tests for the new behaviour

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*